### PR TITLE
Fix missing last_seen_user_agent user property

### DIFF
--- a/user.go
+++ b/user.go
@@ -39,6 +39,7 @@ type User struct {
 	CustomAttributes       map[string]interface{} `json:"custom_attributes,omitempty"`
 	UpdateLastRequestAt    *bool                  `json:"update_last_request_at,omitempty"`
 	NewSession             *bool                  `json:"new_session,omitempty"`
+	LastSeenUserAgent      string                 `json:"last_seen_user_agent,omitempty"`
 }
 
 // LocationData represents the location for a User.

--- a/user_api.go
+++ b/user_api.go
@@ -35,6 +35,7 @@ type requestUser struct {
 	CustomAttributes       map[string]interface{} `json:"custom_attributes,omitempty"`
 	UpdateLastRequestAt    *bool                  `json:"update_last_request_at,omitempty"`
 	NewSession             *bool                  `json:"new_session,omitempty"`
+	LastSeenUserAgent      string                 `json:"last_seen_user_agent,omitempty"`
 }
 
 func (api UserAPI) find(params UserIdentifiers) (User, error) {
@@ -90,6 +91,7 @@ func (api UserAPI) save(user *User) (User, error) {
 		CustomAttributes:       user.CustomAttributes,
 		UpdateLastRequestAt:    user.UpdateLastRequestAt,
 		NewSession:             user.NewSession,
+		LastSeenUserAgent:      user.LastSeenUserAgent,
 	}
 
 	savedUser := User{}


### PR DESCRIPTION
Looks like this one was missed when creating the user types and operations; these small additions fix it up and allow us to populate the user agent info in Intercom as expected.