### PR TITLE
README snippets: use the implicit slice element syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Adding a Company:
 ```go
 companyList := intercom.CompanyList{
 	Companies: []intercom.Company{
-		intercom.Company{ID: "5"},
+		{ID: "5"},
 	},
 }
 user := intercom.User{
@@ -285,14 +285,14 @@ err := ic.Tags.Delete("6")
 #### Tagging Users/Companies
 
 ```go
-taggingList := intercom.TaggingList{Name: "GoTag", Users: []intercom.Tagging{intercom.Tagging{UserID: "27"}}}
+taggingList := intercom.TaggingList{Name: "GoTag", Users: []intercom.Tagging{{UserID: "27"}}}
 savedTag, err := ic.Tags.Tag(&taggingList)
 ```
 
 A `Tagging` can identify a User or Company, and can be set to `Untag`:
 
 ```go
-taggingList := intercom.TaggingList{Name: "GoTag", Users: []intercom.Tagging{intercom.Tagging{UserID: "27", Untag: intercom.Bool(true)}}}
+taggingList := intercom.TaggingList{Name: "GoTag", Users: []intercom.Tagging{{UserID: "27", Untag: intercom.Bool(true)}}}
 savedTag, err := ic.Tags.Tag(&taggingList)
 ```
 


### PR DESCRIPTION
I personally find this more readable.

Before:

```go
[]intercom.Company{
  intercom.Company{ID: "1"},
  intercom.Company{ID: "2"},
  intercom.Company{ID: "3"},
  intercom.Company{ID: "4"},
}
```

After:

```go
[]intercom.Company{
  {ID: "1"},
  {ID: "2"},
  {ID: "3"},
  {ID: "4"},
}
```