### PR TITLE
Fix Nil Pointer Crash

### DIFF
--- a/interfaces/http_client.go
+++ b/interfaces/http_client.go
@@ -48,10 +48,10 @@ func (c IntercomHTTPClient) Get(url string, queryParams interface{}) ([]byte, er
 
 	// Do request
 	resp, err := c.Client.Do(req)
-	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	// Read response
 	data, err := c.readAll(resp.Body)
@@ -99,10 +99,10 @@ func (c IntercomHTTPClient) postOrPatch(method, url string, body interface{}) ([
 
 	// Do request
 	resp, err := c.Client.Do(req)
-	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	// Read response
 	data, err := c.readAll(resp.Body)
@@ -128,10 +128,10 @@ func (c IntercomHTTPClient) Delete(url string, queryParams interface{}) ([]byte,
 
 	// Do request
 	resp, err := c.Client.Do(req)
-	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	// Read response
 	data, err := c.readAll(resp.Body)


### PR DESCRIPTION
I came across a really serious bug which caused a exception to be thrown. But my biggest issue is a design one.

I've hacked in the http.Client as a parameter to the intercom client creation it's necessary if you intend to make HTTP calls on Appengine or for any other use case where you need to define a custom HTTP transport. perhaps keep it like that or provide a workaround in the readme.

Perhaps rename HttpClient to ServiceClient or something else as i found that really confusing.

ty.