### PR TITLE
Company.RemoteCreatedAt: use an int64

### DIFF
--- a/company.go
+++ b/company.go
@@ -20,7 +20,7 @@ type Company struct {
 	ID               string                 `json:"id,omitempty"`
 	CompanyID        string                 `json:"company_id,omitempty"`
 	Name             string                 `json:"name,omitempty"`
-	RemoteCreatedAt  int32                  `json:"remote_created_at,omitempty"`
+	RemoteCreatedAt  int64                  `json:"remote_created_at,omitempty"`
 	LastRequestAt    int32                  `json:"last_request_at,omitempty"`
 	CreatedAt        int32                  `json:"created_at,omitempty"`
 	UpdatedAt        int32                  `json:"updated_at,omitempty"`

--- a/company_api.go
+++ b/company_api.go
@@ -24,7 +24,7 @@ type requestCompany struct {
 	ID               string                 `json:"id,omitempty"`
 	CompanyID        string                 `json:"company_id,omitempty"`
 	Name             string                 `json:"name,omitempty"`
-	RemoteCreatedAt  int32                  `json:"remote_created_at,omitempty"`
+	RemoteCreatedAt  int64                  `json:"remote_created_at,omitempty"`
 	MonthlySpend     int32                  `json:"monthly_spend,omitempty"`
 	Plan             string                 `json:"plan,omitempty"`
 	SessionCount     int32                  `json:"session_count,omitempty"`


### PR DESCRIPTION
This fixes #19. You might want to use `int64` everywhere too.