### PR TITLE
Use v2 imports everywhere

### DIFF
--- a/admin_api.go
+++ b/admin_api.go
@@ -3,7 +3,7 @@ package intercom
 import (
 	"encoding/json"
 
-	"github.com/intercom/intercom-go/interfaces"
+	"gopkg.in/intercom/intercom-go.v2/interfaces"
 )
 
 // AdminRepository defines the interface for working with Admins through the API.

--- a/company_api.go
+++ b/company_api.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/intercom/intercom-go/interfaces"
+	"gopkg.in/intercom/intercom-go.v2/interfaces"
 )
 
 // CompanyRepository defines the interface for working with Companies through the API.

--- a/contact_api.go
+++ b/contact_api.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/intercom/intercom-go/interfaces"
+	"gopkg.in/intercom/intercom-go.v2/interfaces"
 )
 
 // ContactRepository defines the interface for working with Contacts through the API.

--- a/conversation_api.go
+++ b/conversation_api.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/intercom/intercom-go/interfaces"
+	"gopkg.in/intercom/intercom-go.v2/interfaces"
 )
 
 // ConversationRepository defines the interface for working with Conversations through the API.

--- a/doc.go
+++ b/doc.go
@@ -9,7 +9,7 @@ Package intercom-go provides a thin client for the Intercom API: http://doc.inte
 The first step to using Intercom's Go client is to create a client object, using your App ID and Api Key from your [settings](http://app.intercom.io/apps/api_keys).
 
   import (
-    "github.com/intercom/intercom-go"
+    "gopkg.in/intercom/intercom-go.v2"
   )
   ic := intercom.NewClient("appID", "apiKey")
 

--- a/event_api.go
+++ b/event_api.go
@@ -1,6 +1,6 @@
 package intercom
 
-import "github.com/intercom/intercom-go/interfaces"
+import "gopkg.in/intercom/intercom-go.v2/interfaces"
 
 // EventRepository defines the interface for working with Events through the API.
 type EventRepository interface {

--- a/event_api_test.go
+++ b/event_api_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/intercom/intercom-go/interfaces"
+	"gopkg.in/intercom/intercom-go.v2/interfaces"
 )
 
 func TestEventAPISave(t *testing.T) {

--- a/intercom.go
+++ b/intercom.go
@@ -1,7 +1,7 @@
 package intercom
 
 import (
-	"github.com/intercom/intercom-go/interfaces"
+	"gopkg.in/intercom/intercom-go.v2/interfaces"
 )
 
 // A Client manages interacting with the Intercom API.

--- a/job_api.go
+++ b/job_api.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/intercom/intercom-go/interfaces"
+	"gopkg.in/intercom/intercom-go.v2/interfaces"
 )
 
 // JobRepository defines the interface for working with Jobs.

--- a/message_api.go
+++ b/message_api.go
@@ -3,7 +3,7 @@ package intercom
 import (
 	"encoding/json"
 
-	"github.com/intercom/intercom-go/interfaces"
+	"gopkg.in/intercom/intercom-go.v2/interfaces"
 )
 
 // MessageRepository defines the interface for creating and updating Messages through the API.

--- a/segment_api.go
+++ b/segment_api.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/intercom/intercom-go/interfaces"
+	"gopkg.in/intercom/intercom-go.v2/interfaces"
 )
 
 // SegmentRepository defines the interface for working with Segments through the API.

--- a/tag_api.go
+++ b/tag_api.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/intercom/intercom-go/interfaces"
+	"gopkg.in/intercom/intercom-go.v2/interfaces"
 )
 
 // TagRepository defines the interface for working with Tags through the API.

--- a/user_api.go
+++ b/user_api.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/intercom/intercom-go/interfaces"
+	"gopkg.in/intercom/intercom-go.v2/interfaces"
 )
 
 // UserRepository defines the interface for working with Users through the API.


### PR DESCRIPTION
This ensures the v2 code references v2 code *only*.