### PR TITLE
update admin test fixtures to use strings instead for integers for admin ids

### DIFF
--- a/fixtures/admins.json
+++ b/fixtures/admins.json
@@ -4,13 +4,13 @@
         {
             "type": "admin",
             "email": "admin_a@example.io",
-            "id": 1,
+            "id": "1",
             "name": "Admin A"
         },
         {
             "type": "admin",
             "email": "admin_b@example.io",
-            "id": 2,
+            "id": "2",
             "name": "Admin B"
         }
     ]


### PR DESCRIPTION
https://github.com/intercom/intercom-go/blob/v2/admin.go#L10
https://golang.org/pkg/encoding/json/#Number