### PR TITLE
Adding intercom-go Docker image reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Thin client for the [Intercom](https://www.intercom.io) API.
 
 `go get gopkg.in/intercom/intercom-go.v2`
 
+[![docker_image 1](https://cloud.githubusercontent.com/assets/15954251/17524401/5743439e-5e56-11e6-8567-d3d9da1727da.png)](https://hub.docker.com/r/cathalhoran/intercom-go/) <br>
+Try out our [Docker Image (Beta)](https://hub.docker.com/r/cathalhoran/intercom-go/) to help you get started more quickly. <br>
+It should make it easier to get setup with the SDK and start interacting with the API. <br>
+(Note, this is in Beta and is for testing purposes only, it should not be used in production)
+
 ## Usage
 
 ### Getting a Client


### PR DESCRIPTION
Adding go docker to allow for easier testing and development of go issue/features