### PR TITLE
Fixed httpClient panic

### DIFF
--- a/interfaces/http_client.go
+++ b/interfaces/http_client.go
@@ -154,7 +154,7 @@ type IntercomError interface {
 func (c IntercomHTTPClient) parseResponseError(data []byte, statusCode int) IntercomError {
 	errorList := HTTPErrorList{}
 	err := json.Unmarshal(data, &errorList)
-	if err != nil {
+	if err != nil || len(errorList) == 0 {
 		return NewUnknownHTTPError()
 	}
 	httpError := errorList.Errors[0]


### PR DESCRIPTION
On an empty response (i.e. `data` is empty) `json.Unmarshal` will work
i.e. `err` will be nil. However, it'll index into the
`errorList.Errors`, which is an empty array. This has been fixed in
master (SHA: 7b1b1eac8814d9e116662870837006c546716327). Porting the
change over since we are using the v1.0 tag