### PR TITLE
Allow for access token based authorization header

### DIFF
--- a/interfaces/http_client.go
+++ b/interfaces/http_client.go
@@ -38,9 +38,9 @@ func (c IntercomHTTPClient) UserAgentHeader() string {
 func (c IntercomHTTPClient) Get(url string, queryParams interface{}) ([]byte, error) {
 	// Setup request
 	req, _ := http.NewRequest("GET", *c.BaseURI+url, nil)
-	req.SetBasicAuth(c.AppID, c.APIKey)
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("User-Agent", c.UserAgentHeader())
+	req.Header.Add("Authorization", "Bearer " + c.APIKey)
 	addQueryParams(req, queryParams)
 	if *c.Debug {
 		fmt.Printf("%s %s\n", req.Method, req.URL)
@@ -90,9 +90,9 @@ func (c IntercomHTTPClient) postOrPatch(method, url string, body interface{}) ([
 		return nil, err
 	}
 	req.SetBasicAuth(c.AppID, c.APIKey)
-	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("User-Agent", c.UserAgentHeader())
+	req.Header.Add("Authorization", "Bearer " + c.APIKey)
 	if *c.Debug {
 		fmt.Printf("%s %s %s\n", req.Method, req.URL, buffer)
 	}
@@ -118,9 +118,9 @@ func (c IntercomHTTPClient) postOrPatch(method, url string, body interface{}) ([
 func (c IntercomHTTPClient) Delete(url string, queryParams interface{}) ([]byte, error) {
 	// Setup request
 	req, _ := http.NewRequest("DELETE", *c.BaseURI+url, nil)
-	req.SetBasicAuth(c.AppID, c.APIKey)
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("User-Agent", c.UserAgentHeader())
+	req.Header.Add("Authorization", "Bearer " + c.APIKey)
 	addQueryParams(req, queryParams)
 	if *c.Debug {
 		fmt.Printf("%s %s\n", req.Method, req.URL)


### PR DESCRIPTION
The README currently states that you can use the second field in `NewClient` with just an access token. However, the client interface here still only supports basic HTTP authentication instead of setting an `Authorization : Bearer $ACCESS_TOKEN` header on all requests. This fix allows for HTTP authentication with just an access token.