### PR TITLE
Pass status code to the unknown http error

### DIFF
--- a/interfaces/http_client.go
+++ b/interfaces/http_client.go
@@ -155,10 +155,10 @@ func (c IntercomHTTPClient) parseResponseError(data []byte, statusCode int) Inte
 	errorList := HTTPErrorList{}
 	err := json.Unmarshal(data, &errorList)
 	if err != nil {
-		return NewUnknownHTTPError()
+		return NewUnknownHTTPError(statusCode)
 	}
 	if len(errorList.Errors) == 0 {
-		return NewUnknownHTTPError()
+		return NewUnknownHTTPError(statusCode)
 	}
 	httpError := errorList.Errors[0]
 	httpError.StatusCode = statusCode

--- a/interfaces/http_error.go
+++ b/interfaces/http_error.go
@@ -1,6 +1,9 @@
 package interfaces
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 type HTTPErrorList struct {
 	Type   string      `json:"type"`
@@ -13,8 +16,12 @@ type HTTPError struct {
 	Message    string `json:"message"`
 }
 
-func NewUnknownHTTPError() HTTPError {
-	return HTTPError{Code: "Unknown", Message: "Unknown Error"}
+func NewUnknownHTTPError(statusCode int) HTTPError {
+	message := http.StatusText(statusCode)
+	if message == "" {
+		message = "Unknown Error"
+	}
+	return HTTPError{Code: "Unknown", Message: message, StatusCode: statusCode}
 }
 
 func (e HTTPError) Error() string {


### PR DESCRIPTION
When a server response cannot be parsed as json the error should at least contain an http code from the response. 

This patch will help avoiding error messages like `0: Unknown, Unknown Error` appearing in logs when Intercom API returns 504 Gateway Timeout.