### PR TITLE
Fetch the Conversation Message URL

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -30,6 +30,7 @@ type ConversationMessage struct {
 	Subject string         `json:"subject"`
 	Body    string         `json:"body"`
 	Author  MessageAddress `json:"author"`
+	URL     string         `json:"url"`
 }
 
 // A ConversationPartList lists the subsequent Conversation Parts

--- a/conversation_api_test.go
+++ b/conversation_api_test.go
@@ -15,6 +15,9 @@ func TestConversationFind(t *testing.T) {
 	if convo.TagList == nil || convo.TagList.Tags[0].ID != "12345" {
 		t.Errorf("Conversation tags not retrieved, %s", convo.ID)
 	}
+	if convo.ConversationMessage.URL != "/the/page/url.html" {
+		t.Errorf("Conversation URL not retrieved, %s", convo.ConversationMessage.URL)
+	}
 }
 
 func TestConversationRead(t *testing.T) {

--- a/fixtures/conversation.json
+++ b/fixtures/conversation.json
@@ -22,7 +22,8 @@
 		"attachments": [{
 			"name": "signature",
 			"url": "http://someurl.com/signature.jpg"
-		}]
+		}],
+		"url": "/the/page/url.html"
 	},
 	"conversation_parts": {
 		"type": "conversation_part.list",


### PR DESCRIPTION
The URL field is missing from the Conversation Message struct, as defined at https://developers.intercom.com/reference#conversation-model. This simple change just adds field and tests that it's populated correctly.