### PR TITLE
Migrating to CircleCI 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: josler/intercom-go:1.9.4
+
+    working_directory: /go/src/github.com/intercom/intercom-go
+    steps:
+      - checkout
+      - run: go get -v -t -d ./...
+      - run: go build -v
+      - run: go test -v ./...


### PR DESCRIPTION
### Why
We need to migrate the tests to Circle CI 2.0