### PR TITLE
Adding circle to v2 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: josler/intercom-go:1.9.4
+
+    working_directory: /go/src/github.com/intercom/intercom-go
+    steps:
+      - checkout
+      - run: go get -v -t -d ./...
+      - run: go build -v
+      - run: go test -v ./...


### PR DESCRIPTION
#### Why
The Circle updates were added to the Master branch, but the default branch for this repo is V2.