### PR TITLE
Correcting ConversationListPart struct and HTTP client

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -66,12 +66,12 @@ const (
 
 // List all Conversations
 func (c *ConversationService) ListAll(pageParams PageParams) (ConversationList, error) {
-	return c.Repository.list(conversationListParams{PageParams: pageParams})
+	return c.Repository.list(ConversationListParams{PageParams: pageParams})
 }
 
 // List Conversations by Admin
 func (c *ConversationService) ListByAdmin(admin *Admin, state ConversationListState, pageParams PageParams) (ConversationList, error) {
-	params := conversationListParams{
+	params := ConversationListParams{
 		PageParams: pageParams,
 		Type:       "admin",
 		AdminID:    admin.ID.String(),
@@ -87,7 +87,7 @@ func (c *ConversationService) ListByAdmin(admin *Admin, state ConversationListSt
 
 // List Conversations by User
 func (c *ConversationService) ListByUser(user *User, state ConversationListState, pageParams PageParams) (ConversationList, error) {
-	params := conversationListParams{
+	params := ConversationListParams{
 		PageParams:     pageParams,
 		Type:           "user",
 		IntercomUserID: user.ID,
@@ -160,7 +160,7 @@ func (c *ConversationService) Close(id string, closer *Admin) (Conversation, err
 	return c.reply(id, closer, CONVERSATION_CLOSE, "", nil)
 }
 
-type conversationListParams struct {
+type ConversationListParams struct {
 	PageParams
 	Type           string `url:"type,omitempty"`
 	AdminID        string `url:"admin_id,omitempty"`

--- a/conversation_api.go
+++ b/conversation_api.go
@@ -10,7 +10,7 @@ import (
 // ConversationRepository defines the interface for working with Conversations through the API.
 type ConversationRepository interface {
 	find(id string) (Conversation, error)
-	list(params conversationListParams) (ConversationList, error)
+	list(params ConversationListParams) (ConversationList, error)
 	read(id string) (Conversation, error)
 	reply(id string, reply *Reply) (Conversation, error)
 }
@@ -24,7 +24,7 @@ type conversationReadRequest struct {
 	Read bool `json:"read"`
 }
 
-func (api ConversationAPI) list(params conversationListParams) (ConversationList, error) {
+func (api ConversationAPI) list(params ConversationListParams) (ConversationList, error) {
 	convoList := ConversationList{}
 	data, err := api.httpClient.Get("/conversations", params)
 	if err != nil {

--- a/conversation_api_test.go
+++ b/conversation_api_test.go
@@ -77,7 +77,7 @@ func TestConversationReplyWithAttachment(t *testing.T) {
 func TestConversationListAll(t *testing.T) {
 	http := TestConversationHTTPClient{t: t, expectedURI: "/conversations", fixtureFilename: "fixtures/conversations.json"}
 	api := ConversationAPI{httpClient: &http}
-	convos, _ := api.list(conversationListParams{})
+	convos, _ := api.list(ConversationListParams{})
 	if convos.Conversations[0].ID != "147" {
 		t.Errorf("Conversation not retrieved")
 	}
@@ -98,25 +98,25 @@ func TestConversationListAll(t *testing.T) {
 func TestConversationListUserUnread(t *testing.T) {
 	http := TestConversationHTTPClient{t: t, expectedURI: "/conversations", fixtureFilename: "fixtures/conversations.json"}
 	http.testFunc = func(t *testing.T, queryParams interface{}) {
-		ps := queryParams.(conversationListParams)
+		ps := queryParams.(ConversationListParams)
 		if *ps.Unread != true {
 			t.Errorf("Expect unread parameter, got %v", *ps.Unread)
 		}
 	}
 	api := ConversationAPI{httpClient: &http}
-	api.list(conversationListParams{Unread: Bool(true)})
+	api.list(ConversationListParams{Unread: Bool(true)})
 }
 
 func TestConversationListAdminOpen(t *testing.T) {
 	http := TestConversationHTTPClient{t: t, expectedURI: "/conversations", fixtureFilename: "fixtures/conversations.json"}
 	http.testFunc = func(t *testing.T, queryParams interface{}) {
-		ps := queryParams.(conversationListParams)
+		ps := queryParams.(ConversationListParams)
 		if *ps.Open != true {
 			t.Errorf("Expect open parameter, got %v", *ps.Unread)
 		}
 	}
 	api := ConversationAPI{httpClient: &http}
-	api.list(conversationListParams{Open: Bool(true)})
+	api.list(ConversationListParams{Open: Bool(true)})
 }
 
 type TestConversationHTTPClient struct {

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -102,8 +102,8 @@ func TestListAllConversations(t *testing.T) {
 func TestListUserConversationsUnread(t *testing.T) {
 	testAPI := TestConversationAPI{t: t}
 	testAPI.testFunc = func(t *testing.T, params interface{}) {
-		if *params.(conversationListParams).Unread != true {
-			t.Errorf("unread was %v, expected true", *params.(conversationListParams).Unread)
+		if *params.(ConversationListParams).Unread != true {
+			t.Errorf("unread was %v, expected true", *params.(ConversationListParams).Unread)
 		}
 	}
 	conversationService := ConversationService{Repository: testAPI}
@@ -117,8 +117,8 @@ func TestListUserConversationsUnread(t *testing.T) {
 func TestListUserConversationsAll(t *testing.T) {
 	testAPI := TestConversationAPI{t: t}
 	testAPI.testFunc = func(t *testing.T, params interface{}) {
-		if params.(conversationListParams).Unread != nil {
-			t.Errorf("unread was not nil, was %v", *params.(conversationListParams).Unread)
+		if params.(ConversationListParams).Unread != nil {
+			t.Errorf("unread was not nil, was %v", *params.(ConversationListParams).Unread)
 		}
 	}
 	conversationService := ConversationService{Repository: testAPI}
@@ -132,8 +132,8 @@ func TestListUserConversationsAll(t *testing.T) {
 func TestListAdminConversationsAll(t *testing.T) {
 	testAPI := TestConversationAPI{t: t}
 	testAPI.testFunc = func(t *testing.T, params interface{}) {
-		if params.(conversationListParams).Open != nil {
-			t.Errorf("open was not nil, was %v", *params.(conversationListParams).Open)
+		if params.(ConversationListParams).Open != nil {
+			t.Errorf("open was not nil, was %v", *params.(ConversationListParams).Open)
 		}
 	}
 	conversationService := ConversationService{Repository: testAPI}
@@ -147,8 +147,8 @@ func TestListAdminConversationsAll(t *testing.T) {
 func TestListAdminConversationsOpen(t *testing.T) {
 	testAPI := TestConversationAPI{t: t}
 	testAPI.testFunc = func(t *testing.T, params interface{}) {
-		if *params.(conversationListParams).Open != true {
-			t.Errorf("open was not true, was %v", *params.(conversationListParams).Open)
+		if *params.(ConversationListParams).Open != true {
+			t.Errorf("open was not true, was %v", *params.(ConversationListParams).Open)
 		}
 	}
 	conversationService := ConversationService{Repository: testAPI}
@@ -164,7 +164,7 @@ type TestConversationAPI struct {
 	t        *testing.T
 }
 
-func (t TestConversationAPI) list(params conversationListParams) (ConversationList, error) {
+func (t TestConversationAPI) list(params ConversationListParams) (ConversationList, error) {
 	if t.testFunc != nil {
 		t.testFunc(t.t, params)
 	}

--- a/intercom.go
+++ b/intercom.go
@@ -74,7 +74,6 @@ func NewClientWithHTTPClient(appID, apiKey string, httpClient interfaces.HTTPCli
 	return &intercom
 }
 
-
 // TraceHTTP turns on HTTP request/response tracing for debugging.
 func TraceHTTP(trace bool) option {
 	return func(c *Client) option {

--- a/intercom.go
+++ b/intercom.go
@@ -67,6 +67,14 @@ func NewClient(appID, apiKey string) *Client {
 	return &intercom
 }
 
+// Returns a new Intercom API client, configured with the supplied HTTPClient interface
+func NewClientWithHTTPClient(appID, apiKey string, httpClient interfaces.HTTPClient) *Client {
+	intercom := Client{AppID: appID, APIKey: apiKey, baseURI: defaultBaseURI, debug: false, clientVersion: clientVersion, HTTPClient: httpClient}
+	intercom.setup()
+	return &intercom
+}
+
+
 // TraceHTTP turns on HTTP request/response tracing for debugging.
 func TraceHTTP(trace bool) option {
 	return func(c *Client) option {


### PR DESCRIPTION
#### Why
This adds a new method to create an Intercom client using the supplied HTTPClient interface.

This also exports the ConversationListParams object to allow it to be accessed from outside the package.

This was already added to the master branch but needs to be added to V2 as well.