### PR TITLE
Change from travis badge to circle ci badge in ReadMe.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Intercom-Go
 
-[![Build Status](https://travis-ci.org/intercom/intercom-go.svg)](https://travis-ci.org/intercom/intercom-go)
+[![Circle CI](https://circleci.com/gh/intercom/intercom-go.png?style=badge)](https://circleci.com/gh/intercom/intercom-go)
 
 Thin client for the [Intercom](https://www.intercom.io) API.
 


### PR DESCRIPTION
#### Why?
Forgot to remove the travis badge when removing travis from the ci step