### PR TITLE
Add ID to ConversationMessage

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -27,6 +27,7 @@ type Conversation struct {
 
 // A ConversationMessage is the message that started the conversation rendered for presentation
 type ConversationMessage struct {
+	ID      string         `json:"id"`
 	Subject string         `json:"subject"`
 	Body    string         `json:"body"`
 	Author  MessageAddress `json:"author"`


### PR DESCRIPTION
#### Why?

The `ConversationMessage` is currently missing the ID field

#### How?

Added `ID` field with JSON struct tag. If I need to add tests for this feature, happy to do so, but can one of the maintainers please give me a bit of guidance on how/where I should add the tests? I haven't been able to find a lot of docs on the testing practices. Thanks!

