### PR TITLE
adding missing AppID to notification struct

### DIFF
--- a/fixtures/notification.json
+++ b/fixtures/notification.json
@@ -2,6 +2,7 @@
   "type": "notification_event",
   "topic": "company.created",
   "id": "notif_ccd8a4d0-f965-11e3-a367-c779cae3e1b3",
+  "app_id": "a3q03viv",
   "created_at": 1392731331,
   "delivery_attempts": 1,
   "first_sent_at": 1392731392,

--- a/notification.go
+++ b/notification.go
@@ -8,6 +8,7 @@ import (
 // Notification is the object delivered to a webhook.
 type Notification struct {
 	ID               string        `json:"id,omitempty"`
+	AppID            string        `json:"app_id,omitempty"`
 	CreatedAt        int64         `json:"created_at,omitempty"`
 	Topic            string        `json:"topic,omitempty"`
 	DeliveryAttempts int64         `json:"delivery_attempts,omitempty"`

--- a/notification_test.go
+++ b/notification_test.go
@@ -23,6 +23,9 @@ func TestParsingFromReader(t *testing.T) {
 	if n.ID != "notif_ccd8a4d0-f965-11e3-a367-c779cae3e1b3" {
 		t.Errorf("Notification did not have ID")
 	}
+	if n.AppID != "a3q03viv" {
+		t.Errorf("Notification did not have AppID")
+	}
 	if n.CreatedAt != 1392731331 {
 		t.Errorf("Notification did not have CreatedAt")
 	}


### PR DESCRIPTION
#### Why?
Why are you making this change?
Intercom sends AppID in webhook notifications and Notification struct is missing that field

#### How?
Technical details on your change
Added the field, unit test and update the notification fixture
