### PR TITLE
add missing links field to conversation

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -20,9 +20,15 @@ type Conversation struct {
 	Assignee            Admin                `json:"assignee"`
 	Open                bool                 `json:"open"`
 	Read                bool                 `json:"read"`
+	Links               Links                `json:"links"`
 	ConversationMessage ConversationMessage  `json:"conversation_message"`
 	ConversationParts   ConversationPartList `json:"conversation_parts"`
 	TagList             *TagList             `json:"tags"`
+}
+
+// Links represents URLs associated with given conversation
+type Links struct {
+	ConversationWeb string `json:"conversation_web"`
 }
 
 // A ConversationMessage is the message that started the conversation rendered for presentation

--- a/fixtures/conversation.json
+++ b/fixtures/conversation.json
@@ -51,5 +51,8 @@
 			"id": "12345",
 			"name": "Some tag"
 		}]
+	},
+	"links": {
+		"conversation_web": "https://app.intercom.io/a/apps/a3q03viv/inbox/all/conversations/147"
 	}
 }

--- a/fixtures/conversations.json
+++ b/fixtures/conversations.json
@@ -43,6 +43,9 @@
 				},
 				"attachments": []
 			}]
+		},
+		"links": {
+			"conversation_web": "https://app.intercom.io/a/apps/a3q03viv/inbox/all/conversations/147"
 		}
 	}]
 }


### PR DESCRIPTION
#### Why?
Why are you making this change?

Intercom sends links field in the conversation.
A sample snippet when I decoded into map[string]interface
```
"tags": map[string]interface {}{
                 "type": "tag.list",
                 "tags": []interface {}{
                 },
             },
             "links": map[string]interface {}{
                 "conversation_web": "https://app.intercom.io/a/apps/e1q03aiw/inbox/all/conversations/19183230695",
             },
             "assignee": map[string]interface {}{
                 "name":  "Customer Success Team",
                 "email": "e1q03aiw@glidr.intercom-mail.com",
                 "type":  "admin",
                 "id":    "1163989",
             }
```

#### How?
Technical details on your change

I've created a Links struct and added it to Conversation
