### PR TITLE
add missing name field to messageAddress

### DIFF
--- a/message.go
+++ b/message.go
@@ -99,4 +99,5 @@ type MessageAddress struct {
 	ID     string `json:"id,omitempty"`
 	Email  string `json:"email,omitempty"`
 	UserID string `json:"user_id,omitempty"`
+	Name   string `json:"name,omitempty"`
 }


### PR DESCRIPTION
#### Why?
Why are you making this change?

Intercom sends Author name in the ConversationPart and ConversationMessage.

#### How?
Technical details on your change

I've added name field to MessageAddress