### PR TITLE
add conversation_part.tag.created topic

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -44,7 +44,8 @@ func NewNotification(r io.Reader) (*Notification, error) {
 		"conversation.admin.assigned",
 		"conversation.admin.noted",
 		"conversation.admin.closed",
-		"conversation.admin.opened":
+		"conversation.admin.opened",
+		"conversation_part.tag.created":
 		c := &Conversation{}
 		json.Unmarshal(notification.RawData.Item, c)
 		notification.Conversation = c

--- a/notification_test.go
+++ b/notification_test.go
@@ -70,6 +70,7 @@ func TestParsingConverationFromReader(t *testing.T) {
 		"conversation.admin.noted",
 		"conversation.admin.closed",
 		"conversation.admin.opened",
+		"conversation_part.tag.created",
 	}
 
 	for _, topic := range topics {


### PR DESCRIPTION
#### Why?
Why are you making this change?

Intercom sends a conversation_part.tag.created notification. It was missing in the NewNotification function.
https://developers.intercom.com/intercom-api-reference/reference#topics

#### How?
Technical details on your change

I've added conversation_part.tag.created case in NewNotification function.