### PR TITLE
Add Avatar to requestUser structure

### DIFF
--- a/requestUserMapper.go
+++ b/requestUserMapper.go
@@ -3,9 +3,10 @@ package intercom
 // A Company the User belongs to
 // used to update Companies on a User.
 type UserCompany struct {
-	CompanyID string `json:"company_id,omitempty"`
-	Name      string `json:"name,omitempty"`
-	Remove    *bool  `json:"remove,omitempty"`
+	CompanyID        string                 `json:"company_id,omitempty"`
+	Name             string                 `json:"name,omitempty"`
+	Remove           *bool                  `json:"remove,omitempty"`
+	CustomAttributes map[string]interface{} `json:"custom_attributes,omitempty"`
 }
 
 type RequestUserMapper struct{}
@@ -42,9 +43,10 @@ func (rum RequestUserMapper) MakeUserCompaniesFromCompanies(companies []Company)
 	userCompanies := make([]UserCompany, len(companies))
 	for i := 0; i < len(companies); i++ {
 		userCompanies[i] = UserCompany{
-			CompanyID: companies[i].CompanyID,
-			Name:      companies[i].Name,
-			Remove:    companies[i].Remove,
+			CompanyID:        companies[i].CompanyID,
+			Name:             companies[i].Name,
+			Remove:           companies[i].Remove,
+			CustomAttributes: companies[i].CustomAttributes,
 		}
 	}
 	return userCompanies

--- a/requestUserMapper.go
+++ b/requestUserMapper.go
@@ -3,10 +3,9 @@ package intercom
 // A Company the User belongs to
 // used to update Companies on a User.
 type UserCompany struct {
-	CompanyID        string                 `json:"company_id,omitempty"`
-	Name             string                 `json:"name,omitempty"`
-	Remove           *bool                  `json:"remove,omitempty"`
-	CustomAttributes map[string]interface{} `json:"custom_attributes,omitempty"`
+	CompanyID string `json:"company_id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Remove    *bool  `json:"remove,omitempty"`
 }
 
 type RequestUserMapper struct{}
@@ -43,10 +42,9 @@ func (rum RequestUserMapper) MakeUserCompaniesFromCompanies(companies []Company)
 	userCompanies := make([]UserCompany, len(companies))
 	for i := 0; i < len(companies); i++ {
 		userCompanies[i] = UserCompany{
-			CompanyID:        companies[i].CompanyID,
-			Name:             companies[i].Name,
-			Remove:           companies[i].Remove,
-			CustomAttributes: companies[i].CustomAttributes,
+			CompanyID: companies[i].CompanyID,
+			Name:      companies[i].Name,
+			Remove:    companies[i].Remove,
 		}
 	}
 	return userCompanies

--- a/requestUserMapper.go
+++ b/requestUserMapper.go
@@ -17,6 +17,7 @@ func (rum RequestUserMapper) ConvertUser(user *User) requestUser {
 		Phone:                  user.Phone,
 		UserID:                 user.UserID,
 		Name:                   user.Name,
+                Avatar:                 user.Avatar,
 		SignedUpAt:             user.SignedUpAt,
 		RemoteCreatedAt:        user.RemoteCreatedAt,
 		LastRequestAt:          user.LastRequestAt,

--- a/user_api.go
+++ b/user_api.go
@@ -31,7 +31,7 @@ type requestUser struct {
 	Phone                  string                 `json:"phone,omitempty"`
 	UserID                 string                 `json:"user_id,omitempty"`
 	Name                   string                 `json:"name,omitempty"`
-        Avatar                 *UserAatar             `json:"avatar,omitempty"`
+        Avatar                 *UserAvatar            `json:"avatar,omitempty"`
 	SignedUpAt             int64                  `json:"signed_up_at,omitempty"`
 	RemoteCreatedAt        int64                  `json:"remote_created_at,omitempty"`
 	LastRequestAt          int64                  `json:"last_request_at,omitempty"`

--- a/user_api.go
+++ b/user_api.go
@@ -31,6 +31,7 @@ type requestUser struct {
 	Phone                  string                 `json:"phone,omitempty"`
 	UserID                 string                 `json:"user_id,omitempty"`
 	Name                   string                 `json:"name,omitempty"`
+        Avatar                 *UserAatar             `json:"avatar,omitempty"`
 	SignedUpAt             int64                  `json:"signed_up_at,omitempty"`
 	RemoteCreatedAt        int64                  `json:"remote_created_at,omitempty"`
 	LastRequestAt          int64                  `json:"last_request_at,omitempty"`


### PR DESCRIPTION
This is pull request for resolving Issue: [Setting avatar does not work](https://github.com/intercom/intercom-go/issues/80)

Avatar was added to User structure. But it is not in reqeustUser structure. Before posting /user API, User structure is converted to requestUser. Avatar is not defined in requestUser and not copied from User. So avatar setting is not work.

Avatar is added also for requestUser and copied from User.
