### PR TITLE
Expose user type

### DIFF
--- a/user.go
+++ b/user.go
@@ -19,6 +19,7 @@ type UserList struct {
 // stripped out from the request. Please see the API documentation for details.
 type User struct {
 	ID                     string                 `json:"id,omitempty"`
+	Type                   string                 `json:"type,omitempty"`
 	Email                  string                 `json:"email,omitempty"`
 	Phone                  string                 `json:"phone,omitempty"`
 	UserID                 string                 `json:"user_id,omitempty"`


### PR DESCRIPTION
#### Why?
To see the difference between leads and users

Also, gofmt happened. Some go code wasn't properly formatted as per Go standards.

