### PR TITLE
Fix instructions for adding company to user in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Adding a Company:
 ```go
 companyList := intercom.CompanyList{
 	Companies: []intercom.Company{
-		{ID: "5"},
+		{CompanyID: "5"},
 	},
 }
 user := intercom.User{


### PR DESCRIPTION
#### Why?

The `README.md` instructions for adding a company for a user are incorrect. They don't match [the API docs](https://developers.intercom.com/intercom-api-reference/reference#companies-and-users) and they throw an error when used in the real world, even though it compiles correctly.

This fixes the docs so other people don't run into the same issue 🙂 

#### How?

N/A
