### PR TITLE
Add missing annotation on Contacts property in ContactList

### DIFF
--- a/contact.go
+++ b/contact.go
@@ -10,7 +10,7 @@ type ContactService struct {
 // ContactList holds a list of Contacts and paging information
 type ContactList struct {
 	Pages    PageParams
-	Contacts []Contact
+	Contacts []Contact `json:"data"`
 	ScrollParam string `json:"scroll_param,omitempty"`
 }
 


### PR DESCRIPTION
#### Why?
The Contacts list would always be empty because of the missing JSON annotation on the Contacts field, e.g. when doing

```
contactList, err := ic.Contacts.List(intercom.PageParams{Page: 2})
contactList.Contacts
```
contactList.Contacts would be empty.

#### How?

Added JSON annotation.
