### PR TITLE
[ Bug Fix ] change json tag for ConversationMessage field in Conversation struct

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -20,7 +20,7 @@ type Conversation struct {
 	Assignee            Admin                `json:"assignee"`
 	Open                bool                 `json:"open"`
 	Read                bool                 `json:"read"`
-	ConversationMessage ConversationMessage  `json:"conversation_message"`
+	ConversationMessage ConversationMessage  `json:"source"`
 	ConversationParts   ConversationPartList `json:"conversation_parts"`
 	TagList             *TagList             `json:"tags"`
 }


### PR DESCRIPTION
#### Why?
As per the `conversation` model documentation here https://developers.intercom.com/intercom-api-reference/reference#conversation-model
It does not have any field with the name `conversation_message` and there is no such field available in the response as well

Though as per the code comments

`// A ConversationMessage is the message that started the conversation rendered for presentation`

Which maps to the `source` field mentioned in the documentation

`The Conversation Part that originated this conversation, which can be Contact, Admin, Campaign, Automated or Operator initiated.`

Based on this, we should be populating the ConversationMessage struct from the `source` field in the response
 
 
   
  

#### How?
Technical details on your change

- Changed the json tag for `ConversationMessage` field in the `Conversation` struct from `conversation_message` to `source`, which fixes the issue
        